### PR TITLE
Removed commented free(image_path)

### DIFF
--- a/imgfb.c
+++ b/imgfb.c
@@ -142,7 +142,7 @@ int main(int argc, char* argv[]) {
 	} else {
 		image_stream = fopen(image_path, "r");
 	}
-	//free(image_path); // this crashes for some reason
+
 	if (!image_stream) ERROR;
 
 	uint32_t image_w;


### PR DESCRIPTION
image_path is getting assigned to argv[i] on line 83, that's why freeing it causes a crash. Because it isn't allocated on the heap. So you can remove the commented line.