### PR TITLE
Seperate stb_image from imgfb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,22 @@ CC=cc
 CFLAGS=-Wall -O2
 LFLAGS=-lm
 
+OBJS=stb_image.o imgfb.o
+
 TARGET=imgfb
 
 .PHONY: all clean
 
 all: $(TARGET)
 
-$(TARGET): imgfb.c
-	$(CC) $(CFLAGS) -o $@ $^ $(LFLAGS)
+# Make the target depend on all the objects instead of 1 source file
+$(TARGET): $(OBJS)
+	$(CC) -o $@ $^ $(LFLAGS)
+
+# This rule compiles each source file (.c) into an object file (.o)
+# each time the source is changed
+%.o: %.c
+	$(CC) -c $(CFLAGS) -o $@ $<
 
 clean:
-	rm -fv imgfb
+	rm -fv $(OBJS) $(TARGET)

--- a/imgfb.c
+++ b/imgfb.c
@@ -5,7 +5,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
-#define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
 int usage(char *argv0) {

--- a/stb_image.c
+++ b/stb_image.c
@@ -1,0 +1,2 @@
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"


### PR DESCRIPTION
This will make compiling time faster, since we won't be compiling stb_image each time we make a change in imgfb.c.